### PR TITLE
🔧 Set API_URL to .env reference

### DIFF
--- a/client/src/components/Resume.tsx
+++ b/client/src/components/Resume.tsx
@@ -9,11 +9,13 @@ import './Resume.css';
 import ResumeEntry from './ResumeEntry';
 import TextInput from './TextInput';
 import { useEffect } from 'react';
-//import { Large } from '../stories/Button.stories';
 import SocialLinks from './SocialLinks';
 import { useAuth0 } from '@auth0/auth0-react';
 import Loading from './Loading';
-import { createTrue } from 'typescript';
+
+const API_URL = process.env.REACT_APP_API_URL
+  ? process.env.REACT_APP_API_URL
+  : 'https://localhost:5000/api/';
 
 type ResumeProps = {
   /** UserID of resume to get. If left blank, the logged in user will be fetched */
@@ -60,7 +62,7 @@ function Resume(props: ResumeProps) {
     // Call API
     try {
       const token = await getAccessTokenSilently();
-      const res = await fetch('/api/' + route, {
+      const res = await fetch(API_URL + route, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -129,7 +131,7 @@ function Resume(props: ResumeProps) {
       // Call API
       try {
         const token = await getAccessTokenSilently();
-        const res = await fetch('/api/' + route, {
+        const res = await fetch(API_URL + route, {
           method: 'PUT',
           headers: {
             Authorization: `Bearer ${token}`,

--- a/client/src/pages/APITest.tsx
+++ b/client/src/pages/APITest.tsx
@@ -13,6 +13,10 @@ const { Option } = Select;
 const { Search } = Input;
 const { Paragraph, Text } = Typography;
 
+const API_URL = process.env.REACT_APP_API_URL
+  ? process.env.REACT_APP_API_URL
+  : 'https://localhost:5000/api/';
+
 /**
  * Items before the API route input
  */
@@ -21,7 +25,7 @@ const selectBefore = (
     <Select defaultValue="GET" className="select-before">
       <Option value="GET">GET</Option>
     </Select>
-    <span> https://localhost:5000/api/</span>
+    <span> {API_URL}</span>
   </>
 );
 
@@ -56,7 +60,7 @@ function APITest() {
   /**
    * Used to call the API with the authentication token passed in automatically
    *
-   * @param route Route to call at https://localhost:5000/api/{route}
+   * @param route Route to call
    * @param callback Callback function with the the response JSON as data
    */
   async function callAPI(route: string, callback: (data: Object) => void) {
@@ -125,7 +129,7 @@ function APITest() {
             <Search
               addonBefore={selectBefore} //"GET https://localhost:5000/api/"
               defaultValue="test"
-              onSearch={(value) => callAPI(`/api/${value}`, setAPIResult)}
+              onSearch={(value) => callAPI(`${API_URL}${value}`, setAPIResult)}
             />
           </div>
 
@@ -135,7 +139,7 @@ function APITest() {
             style={{ width: 600, display: 'flex', justifyContent: 'center' }}
           >
             <Search
-              defaultValue="enter search URL"
+              placeholder="Enter API route"
               onSearch={(value) => callAPI(value, setAPIResult)}
             />
           </div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -27,17 +27,6 @@ function Home() {
         <FilterAndSort />
         <PortfolioGrid />
       </div>
-
-      {isAuthenticated ? (
-        <div>
-          <h2> User: {user.name} </h2>
-          <p> Email: {user.email} </p>
-        </div>
-      ) : (
-        <div>
-          <h2> Not logged in </h2>
-        </div>
-      )}
     </div>
   );
 }

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -14,6 +14,10 @@ import Resume from '../components/Resume';
 import PortfolioGrid from '../components/PortfolioGrid';
 import PrivateProfileWarning from '../components/PrivateProfileWarning';
 
+const API_URL = process.env.REACT_APP_API_URL
+  ? process.env.REACT_APP_API_URL
+  : 'https://localhost:5000/api/';
+
 type ParamType = {
   userID: string;
 };
@@ -54,7 +58,7 @@ function Profile() {
 
     try {
       const token = await getAccessTokenSilently();
-      await fetch('/api/' + route, {
+      await fetch(API_URL + route, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -113,7 +117,7 @@ function Profile() {
 
     try {
       const token = await getAccessTokenSilently();
-      await fetch('/api/' + route, {
+      await fetch(API_URL + route, {
         headers: {
           Authorization: `Bearer ${token}`,
         },

--- a/client/src/pages/ProfileSetup.tsx
+++ b/client/src/pages/ProfileSetup.tsx
@@ -13,6 +13,10 @@ import Loading from '../components/Loading';
 import Resume from '../components/Resume';
 import PortfolioGrid from '../components/PortfolioGrid';
 
+const API_URL = process.env.REACT_APP_API_URL
+  ? process.env.REACT_APP_API_URL
+  : 'https://localhost:5000/api/';
+
 type ParamType = {
   userID: string;
 };
@@ -53,7 +57,7 @@ function ProfileSetup() {
 
     try {
       const token = await getAccessTokenSilently();
-      await fetch('/api/' + route, {
+      await fetch(API_URL + route, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
@@ -114,7 +118,7 @@ function ProfileSetup() {
 
     try {
       const token = await getAccessTokenSilently();
-      await fetch('/api/' + route, {
+      await fetch(API_URL + route, {
         headers: {
           Authorization: `Bearer ${token}`,
         },


### PR DESCRIPTION
Hopefully will fix up the frontend API issues on production

Basically just prefixes API calls with `REACT_APP_API_URL` as defined in `client/.env`

For local dev, it's set up so that if there's no such variable `.env` it defaults to `https://localhost:5000/api/` but it might be a good idea to add it anyway

@neatht could you please add `REACT_APP_API_URL=https://www.glowbal.us.to:5000/api/` to `/client/.env` on prod?
